### PR TITLE
fix verb

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ README
 ===
 
 Codakido is a (currently) rudimental attempt at creating a Codea-inspired
-environment to learn children how to write Lua programs.
+environment to teach children how to write Lua programs.
 
 It is written in ANSI C and uses SDL, so should compile on Mac OS X and Linux
 without issues.


### PR DESCRIPTION
According to this: http://en.wiktionary.org/wiki/learn#Etymology_2

the usage of "learn" instead of "teach" is often considered non-standard. It is better to use the most known (and used) "teach".

Keep it up e buon lavoro
