### PR TITLE
Add lua/src to include path to fix build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: codakido
 
 codakido: codakido.c lua/src/liblua.a
-	$(CC) -O2 -Wall -W $< `sdl-config --cflags` `sdl-config --libs` -lm lua/src/liblua.a -o $@
+	$(CC) -Ilua/src -O2 -Wall -W $< `sdl-config --cflags` `sdl-config --libs` -lm lua/src/liblua.a -o $@
 
 lua/src/liblua.a:
 	-(cd lua && $(MAKE) ansi)


### PR DESCRIPTION
"make" failed for me with:

  cc -O2 -Wall -W codakido.c `sdl-config --cflags` `sdl-config --libs` -lm lua/src/liblua.a -o codakido
  codakido.c:30:17: error: lua.h: No such file or directory
  codakido.c:31:21: error: lauxlib.h: No such file or directory
  codakido.c:32:20: error: lualib.h: No such file or directory

Fixed by adding -Ilua/src to cc line.

Thanks for another interesting code base. I was thinking just yesterday about teaching my kids programming so this is brilliant timing.
