### PR TITLE
process multiple SDL events per tick

### DIFF
--- a/load81.c
+++ b/load81.c
@@ -523,7 +523,7 @@ int processSdlEvents(void) {
     SDL_Event event;
 
     resetEvents();
-    if (SDL_PollEvent(&event)) {
+    while (SDL_PollEvent(&event)) {
         switch(event.type) {
         case SDL_KEYDOWN:
             switch(event.key.keysym.sym) {


### PR DESCRIPTION
This greatly reduces input lag.

Fixes #17.
