### PR TITLE
Bugfix in Pandora Makefile

### DIFF
--- a/contrib/Pandora/Makefile
+++ b/contrib/Pandora/Makefile
@@ -1,10 +1,12 @@
+all:	pnd-file
 
 pnd-file:
-	cp -rfv ../../examples/* PND_Resources/examples
+	rm -rf PND_Resources/examples/ && mkdir PND_Resources/examples/
+	cp -rfv ../../examples/* PND_Resources/examples/
 	cp ../../load81 PND_Resources/
 	./pnd_make.sh -c -d PND_Resources/ -x PND_Resources/PXML.xml -i PND_Resources/icon.png -p ./LOAD81.pnd
 
 clean:
-	rm -rf PND_Resources/examples/*
+	rm -rf PND_Resources/examples/
 	rm -f PND_Resources/load81
-	rm -f LOAD81.pnd
+	rm -f LOAD81.pnd   


### PR DESCRIPTION
I previously committed the contrib/Pandora tree with an empty examples/ directory - this was pruned during the last merge, as it is an empty directory.  So I have modified the Makefile to create this directory properly as a resource when the PND file is made.
