### PR TITLE
Change to accomodate --bpp arg setting

### DIFF
--- a/contrib/Pandora/PND_Resources/defconf/profile.txt
+++ b/contrib/Pandora/PND_Resources/defconf/profile.txt
@@ -9,6 +9,7 @@ filepath=./examples/
 exepath=./load81 --full
 extarg=--width;0;%na%;800
 extarg=--height;0;%na%;480
+extarg=--bpp;0;%na%;16
 extarg=;0;%na%;%filename%
 
 # Custom Entries Settings


### PR DESCRIPTION
The --bpp arg was added to LOAD81 - this change accommodates this new arg, setting the bpp for the Open Pandora to 16.  NOTE: --bpp 32 breaks Alpha, --bpp 24 reduces framerate to 20fps, --bpp 16 produces acceptable color depth and average of 30fps
