### PR TITLE
update dependencies in README, use portable SDL type names 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ ESC key.
 
 ![Load81 Asteroids](http://antirez.com/misc/codakido_screenshot_3.png)
 
-Load81 is written in ANSI C and uses SDL, so should compile on Mac OS X, Linux
-and Windows without issues.
+Load81 is written in ANSI C and uses SDL and SDL_gfx, so should compile on 
+Mac OS X, Linux and Windows without issues.
 
 The coordinate system and the basic drawing functions are compatible with
 Codea (check http://twolivesleft.com/Codea/ for more information), but there

--- a/load81.c
+++ b/load81.c
@@ -213,8 +213,8 @@ int backgroundBinding(lua_State *L) {
 }
 
 int getpixelBinding(lua_State *L) {
-    uint32_t pixel;
-    uint8_t r, g, b;
+    Uint32 pixel;
+    Uint8 r, g, b;
     int x, y;
 
     x = lua_tonumber(L,-2);
@@ -232,14 +232,14 @@ int getpixelBinding(lua_State *L) {
                              (y*l81.fb->screen->pitch)+(x*bpp);
         switch(bpp) {
         case 1: pixel = *p; break;
-        case 2: pixel = *(uint16_t *)p; break;
+        case 2: pixel = *(Uint16 *)p; break;
         case 3:
 #if SDL_BYTEORDER == SDL_LIL_ENDIAN
             pixel = p[0]|p[1]<<8|p[2]<<16;
 #else
             pixel = p[2]|p[1]<<8|p[0]<<16;
 #endif
-        case 4: pixel = *(uint32_t*)p; break;
+        case 4: pixel = *(Uint32*)p; break;
         default: return 0; break;
         }
     }


### PR DESCRIPTION
I substituted Uint8 for uint8_t etc. because my old compiler doesn't know about uint8_t, 
but SDL always provides Uint8, so I guess this is more portable.
