### PR TITLE
catch errors in setup()

### DIFF
--- a/load81.c
+++ b/load81.c
@@ -372,7 +372,10 @@ int processSdlEvents(void) {
     }
 
     /* Call the setup function, only the first time. */
-    if (l81.epoch == 0) setup();
+    if (l81.epoch == 0) {
+        setup();
+        if (l81.luaerr) return l81.luaerr;
+    }
     /* Call the draw function at every iteration.  */
     draw();
     l81.epoch++;


### PR DESCRIPTION
Previously draw() would be executed even if setup() failed, likely crashing the Lua program mysteriously.
