### PR TITLE
Editor can accept new file without crashing

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -326,6 +326,9 @@ int editorOpen(char *filename) {
     FILE *fp;
     char line[1024];
 
+    E.dirty = 0;
+    free(E.filename);
+    E.filename = strdup(filename);
     /* TODO: remove old program from rows. */
     fp = fopen(filename,"r");
     if (!fp) {
@@ -340,9 +343,6 @@ int editorOpen(char *filename) {
         editorInsertRow(E.numrows,line);
     }
     fclose(fp);
-    E.dirty = 0;
-    free(E.filename);
-    E.filename = strdup(filename);
     return 0;
 }
 


### PR DESCRIPTION
Hi, this enables to execute load81 with new file as parameter.  Before this change when you hit ESC the editor was trying to access the filename and it was null because 'editorOpen' returned before settings the name.
