### PR TITLE
Fix keyboard issues

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -646,6 +646,7 @@ int editorEvents(void) {
             case SDLK_LMETA:
             case SDLK_RMETA:
             case SDLK_CAPSLOCK:
+            case SDLK_MODE:
                 /* Ignored */
                 break;
             case SDLK_TAB:

--- a/editor.c
+++ b/editor.c
@@ -654,6 +654,8 @@ int editorEvents(void) {
                 break;
             default:
                 editorInsertChar(E.key[j].translation);
+                /* Avoid repetition for special characters. */
+                if (j == SDLK_UNKNOWN) E.key[j].counter = 0;
                 break;
             }
         }


### PR DESCRIPTION
* Changes in editor.c: 
  * Ignore AltGr key. 
Currently is being printed as '?'. In some keyboards is reported as SDLK_RALT but in others it has its own code (SDLK_MODE) [1].
  * Avoid repetition mechanism SDLK_UNKNOWN characters. 
There are characters that can only be typed as the combination of several keys asynchronously. 
For instance, tilde characters such as 'â' are typed, in Spanish keyboard, as Shift + '^' + (pause) + 'a'. By the time the key 'a' is pressed, the other previous keys were already released. This sequence makes impossible to type these kind of characters repeatedly.
What is happening now is that introducing one single '^' character introduces this character in the editor endlessly (the reason is that the counter of the pressed key should be dependent on the previously pressed keys I think). I noticed that the reported key symbol for these type of characters is always SDLK_UNKNOWN, so I reset its counter to zero.

[1] http://tinlizzie.org/svn/trunk/bottle/SDL/SDL_keysym.h