### PR TITLE
Remove warnings when compiling with GCC 10.2.1 20201203 on Linux, fix #66

### DIFF
--- a/load81.c
+++ b/load81.c
@@ -213,7 +213,6 @@ int backgroundBinding(lua_State *L) {
 }
 
 int getpixelBinding(lua_State *L) {
-    Uint32 pixel;
     int x, y;
     unsigned char rgb[3];
 
@@ -221,7 +220,7 @@ int getpixelBinding(lua_State *L) {
     y = l81.fb->height - 1 - lua_tonumber(L,-1);
 
     if (x < 0 || x >= l81.fb->width || y < 0 || y >= l81.fb->height) {
-        pixel = 0;
+        rgb[0] = rgb[1] = rgb[2] = 0;
     } else {
         SDL_Rect rect = {x,y,1,1};
         SDL_RenderReadPixels(l81.fb->renderer,&rect,SDL_PIXELFORMAT_BGR888,

--- a/lua/src/lauxlib.c
+++ b/lua/src/lauxlib.c
@@ -574,7 +574,7 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
-   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
+    while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
     lf.extraline = 0;
   }
   ungetc(c, lf.f);
@@ -649,4 +649,3 @@ LUALIB_API lua_State *luaL_newstate (void) {
   if (L) lua_atpanic(L, &panic);
   return L;
 }
-

--- a/lua/src/ltablib.c
+++ b/lua/src/ltablib.c
@@ -135,9 +135,9 @@ static int tremove (lua_State *L) {
 static void addfield (lua_State *L, luaL_Buffer *b, int i) {
   lua_rawgeti(L, 1, i);
   if (!lua_isstring(L, -1))
-    luaL_error(L, "invalid value (%s) at index %d in table for "
-                  LUA_QL("concat"), luaL_typename(L, -1), i);
-    luaL_addvalue(b);
+    return luaL_error(L, "invalid value (%s) at index %d in table for "
+                      LUA_QL("concat"), luaL_typename(L, -1), i);
+  luaL_addvalue(b);
 }
 
 
@@ -284,4 +284,3 @@ LUALIB_API int luaopen_table (lua_State *L) {
   luaL_register(L, LUA_TABLIBNAME, tab_funcs);
   return 1;
 }
-


### PR DESCRIPTION
This leaves only one warning:
```
/usr/bin/ld: liblua.a(loslib.o): in function `os_tmpname':
loslib.c:(.text+0x4e4): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
```
There is a note about this in `lua/src/luaconf.h`:

> lua_tmpnam is the function that the OS library uses to create a temporary name.
> LUA_TMPNAMBUFSIZE is the maximum size of a name created by lua_tmpnam.
> CHANGE them if you have an alternative to tmpnam (which is considered insecure) or if you want the original tmpnam anyway.
> By default, Lua uses tmpnam except when POSIX is available, where it uses mkstemp.

If I understand this correctly, when running on Linux it would not use `tmpnam` anyway. If so, it would be nice to quiet this warning too.